### PR TITLE
Passing self with district now. Optimized district creation to ignore…

### DIFF
--- a/lib/district.rb
+++ b/lib/district.rb
@@ -1,12 +1,8 @@
 class District
-  attr_reader :name
+  attr_reader :name, :dr
 
-  def initialize(input)
-    @name = name_generator(input)
+  def initialize(input, district_repo = nil)
+    @name = input[:name]
+    @dr = district_repo
   end
-
-  def name_generator(input)
-    input[:name].upcase
-  end
-
 end

--- a/lib/district_repository.rb
+++ b/lib/district_repository.rb
@@ -11,14 +11,13 @@ class DistrictRepository
     filename = path[:enrollment][:kindergarten]
     CSV.foreach(filename, headers: true, header_converters: :symbol) do |row|
       name = row[:location]
-      d = District.new({:name => name})
-      @districts[name] = d
+      d = District.new({:name => name}, self)
+      @districts[name] = d if @districts[name] == 0
     end
   end
 
   def find_by_name(name)
-    @districts[(name.upcase.to_sym)] if @districts[(name.upcase.to_sym)] != 0
-    binding.pry
+    @districts[(name.upcase)] if @districts[(name.upcase)] != 0
   end
 
   def find_all_matching(names)

--- a/test/district_test.rb
+++ b/test/district_test.rb
@@ -1,5 +1,6 @@
 require './test/test_helper'
 require './lib/district'
+require './lib/district_repository'
 
 class DistrictTest < MiniTest::Test
 
@@ -10,14 +11,12 @@ class DistrictTest < MiniTest::Test
 
   def test_district_has_name
     district = District.new({:name => "ACADEMY 20"})
-    assert_equal 1, district.count
-
+    assert_equal "ACADEMY 20", district.name
   end
 
-  def test_name_generator_can_make_capitalize_name
-    def test_district_has_name
-      district = District.new({:name => "ACADEMY 20"})
-      assert_equal "ACADEMY 20", district.name
-    end
+  def test_district_can_hold_district_repository
+    dr = DistrictRepository.new
+    district = District.new({:name => "ACADEMY 20"}, dr)
+    assert_instance_of DistrictRepository, district.dr
   end
 end


### PR DESCRIPTION
No more duplicate districts will be made. If it exists it will move to the next. This should increase our run times when parsing larger files. We are also passing the District Repo with the districts so we can us it in the next iteration.

![image](https://cloud.githubusercontent.com/assets/20252614/21704566/7f905a76-d377-11e6-8bac-da0eecaddd04.png)
